### PR TITLE
Support CyHy Notifications

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.2.3
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: markdownlint
         # The LICENSE.md must match the license text exactly for
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.4
+    rev: 1.0.5
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
@@ -45,11 +45,11 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.16.3
+    rev: v1.17.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 2a1dbab
+    rev: 1.6.0
     hooks:
       - id: bandit
         args:
@@ -74,6 +74,6 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.17.0
+    rev: 1.17.1
     hooks:
       - id: prettier

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@
 dist: xenial
 language: python
 python: 3.7
+# pre-commit hooks can use Docker, so we should go ahead and enable it
 services: docker
+
+# Cache pip packages and pre-commit plugins to speed up builds
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 
 install:
   - pip install --upgrade -r requirements-test.txt

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -23,6 +23,9 @@ def test_packages(host, pkg):
         "/var/cyhy/reports",
         "/var/cyhy/reports/output",
         "/var/cyhy/reports/create_snapshots_reports_scorecard.py",
+        "/var/cyhy/notifications",
+        "/var/cyhy/notifications/output",
+        "/var/cyhy/notifications/create_send_notifications.py",
     ],
 )
 def test_files(host, f):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,13 +59,18 @@
   loop:
     - /var/cyhy/reports
     - /var/cyhy/reports/output
+    - /var/cyhy/notifications
+    - /var/cyhy/notifications/output
 
-- name: Copy the reporting script
+- name: Copy the reporting and notification scripts
   copy:
-    src: /var/local/cyhy/reports/extras/create_snapshots_reports_scorecard.py
-    dest: /var/cyhy/reports/create_snapshots_reports_scorecard.py
+    src: "/var/local/cyhy/reports/extras/{{ item }}"
+    dest: "/var/cyhy/reports/{{ item }}"
     mode: 0755
     remote_src: yes
+  loop:
+    - create_snapshots_reports_scorecard.py
+    - create_send_notifications.py
 
 # rsync is required by synchronize
 - name: Install rsync

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,8 +11,7 @@
 
 - name: Download and untar the cyhy-reports tarball
   unarchive:
-    # TODO revert back to develop when done testing
-    src: "https://api.github.com/repos/jsf9k/cyhy-reports/tarball/improvement/cyhy_notifications?\
+    src: "https://api.github.com/repos/jsf9k/cyhy-reports/tarball/develop?\
     access_token={{ github_oauth_token }}"
     dest: /var/local/cyhy/reports
     remote_src: yes
@@ -70,8 +69,8 @@
     mode: 0755
     remote_src: yes
   loop:
-    - { script: "create_snapshots_reports_scorecard.py", dest_dir: "reports" }
-    - { script: "create_send_notifications.py", dest_dir: "notifications" }
+    - {script: "create_snapshots_reports_scorecard.py", dest_dir: "reports"}
+    - {script: "create_send_notifications.py", dest_dir: "notifications"}
 
 # rsync is required by synchronize
 - name: Install rsync

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,13 +65,13 @@
 
 - name: Copy the reporting and notification scripts
   copy:
-    src: "/var/local/cyhy/reports/extras/{{ item }}"
-    dest: "/var/cyhy/reports/{{ item }}"
+    src: "/var/local/cyhy/reports/extras/{{ item.script }}"
+    dest: "/var/cyhy/{{ item.dest_dir }}/{{ item.script }}"
     mode: 0755
     remote_src: yes
   loop:
-    - create_snapshots_reports_scorecard.py
-    - create_send_notifications.py
+    - { script: "create_snapshots_reports_scorecard.py", dest_dir: "reports" }
+    - { script: "create_send_notifications.py", dest_dir: "notifications" }
 
 # rsync is required by synchronize
 - name: Install rsync

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,8 @@
 
 - name: Download and untar the cyhy-reports tarball
   unarchive:
-    src: "https://api.github.com/repos/jsf9k/cyhy-reports/tarball/develop?\
+    # TODO revert back to develop when done testing
+    src: "https://api.github.com/repos/jsf9k/cyhy-reports/tarball/improvement/cyhy_notifications?\
     access_token={{ github_oauth_token }}"
     dest: /var/local/cyhy/reports
     remote_src: yes


### PR DESCRIPTION
In addition to pulling in upstream changes from skeleton-ansible-role, this PR sets up the directories and script (`create_send_notifications.py`) involved in CyHy daily notification PDFs and emails.

Note that this PR should be deployed in conjunction with the latest cyhy-reports PR.