### PR TITLE
Move notification script to /var/cyhy/reports

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -23,9 +23,7 @@ def test_packages(host, pkg):
         "/var/cyhy/reports",
         "/var/cyhy/reports/output",
         "/var/cyhy/reports/create_snapshots_reports_scorecard.py",
-        "/var/cyhy/notifications",
-        "/var/cyhy/notifications/output",
-        "/var/cyhy/notifications/create_send_notifications.py",
+        "/var/cyhy/reports/create_send_notifications.py",
     ],
 )
 def test_files(host, f):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,18 +59,16 @@
   loop:
     - /var/cyhy/reports
     - /var/cyhy/reports/output
-    - /var/cyhy/notifications
-    - /var/cyhy/notifications/output
 
 - name: Copy the reporting and notification scripts
   copy:
-    src: "/var/local/cyhy/reports/extras/{{ item.script }}"
-    dest: "/var/cyhy/{{ item.dest_dir }}/{{ item.script }}"
+    src: "/var/local/cyhy/reports/extras/{{ item }}"
+    dest: "/var/cyhy/reports/{{ item }}"
     mode: 0755
     remote_src: yes
   loop:
-    - {script: "create_snapshots_reports_scorecard.py", dest_dir: "reports"}
-    - {script: "create_send_notifications.py", dest_dir: "notifications"}
+    - create_snapshots_reports_scorecard.py
+    - create_send_notifications.py
 
 # rsync is required by synchronize
 - name: Install rsync


### PR DESCRIPTION
This puts it back in the same directory as the CyHy report generator script, making our directory structure a bit cleaner.

This PR should be deployed in conjunction with cisagov/cyhy-mailer#54 and cisagov/cyhy_amis#209.