### PR TITLE
Update for cisagov move

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,0 @@
----
-# The GitHub OAUTH token
-github_oauth_token: "{{ lookup('aws_ssm', '/github/oauth_token') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,8 +11,7 @@
 
 - name: Download and untar the cyhy-reports tarball
   unarchive:
-    src: "https://api.github.com/repos/jsf9k/cyhy-reports/tarball/develop?\
-    access_token={{ github_oauth_token }}"
+    src: "https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop"
     dest: /var/local/cyhy/reports
     remote_src: yes
     extra_opts:
@@ -23,7 +22,7 @@
 #
 
 # These dependencies are from here:
-# https://github.com/jsf9k/cal-overlay/blob/develop/net-analyzer/cyhy-reports/cyhy-reports-1.0.12.ebuild#L31-L49
+# https://github.com/cisagov/cal-overlay/blob/develop/net-analyzer/cyhy-reports/cyhy-reports-1.0.12.ebuild#L31-L49
 #
 # I'd prefer to install the python dependencies via pip, but then I
 # get errors about modules being built with a different version of

--- a/terraform/iam_user.tf
+++ b/terraform/iam_user.tf
@@ -10,6 +10,6 @@ module "iam_user" {
   }
 
   entity         = "ansible-role-cyhy-reports"
-  ssm_parameters = ["/github/oauth_token", "/cyhy/core/geoip/license_key"]
+  ssm_parameters = ["/cyhy/core/geoip/license_key"]
   tags           = var.tags
 }


### PR DESCRIPTION
Update URLs for move to `cisagov` org and remove unnecessary oauth url

## 🗣 Description

- Updates target URL for the move to the `cisagov` org
- Removes oauth from URL query to retrieve tarball since it's now a public repo

## 💭 Motivation and Context

Associated with https://github.com/cisagov/ansible-role-cyhy-core/issues/10 - removes deprecated oauth usage both due to deprecation as well as now the target is publicly accessible without an auth token.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
