### PR TITLE
Update the supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,9 +15,15 @@ galaxy_info:
   min_ansible_version: 2.10
   namespace: cisagov
   platforms:
+    # cyhy-reports is still Python 2 and with distributions ending support for
+    # Python 2 we can only support a limited number of platforms.
     - name: Debian
       versions:
         - stretch
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
   role_name: cyhy_reports
 
 dependencies:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,16 +16,15 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  # cyhy-reports is Python 2 only, and the only platform we currently support
-  # for Python 2 is Debian Stretch. Until this restriction changes we need to
-  # disable testing for all other platforms.
+  # cyhy-reports is still Python 2 and with distributions ending support for
+  # Python 2 we can only support a limited number of platforms.
   # - name: amazonlinux2
   #   image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
-  # - name: debian10
-  #   image: debian:buster-slim
+  - name: debian10
+    image: debian:buster-slim
   # - name: debian11
   #   image: debian:bullseye-slim
   # - name: debian12
@@ -36,8 +35,8 @@ platforms:
   #   image: fedora:34
   # - name: fedora35
   #   image: fedora:35
-  # - name: ubuntu18
-  #   image: ubuntu:bionic
+  - name: ubuntu18
+    image: ubuntu:bionic
   # - name: ubuntu20
   #   image: ubuntu:focal
 provisioner:

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -4,6 +4,9 @@
   become: yes
   become_method: sudo
   roles:
-    - pip
-    - python
-    - remove_python2
+    - role: pip
+      vars:
+        install_pip2: true
+    - role: python
+      vars:
+        install_python2: true

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -7,7 +7,5 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,15 +1,11 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
-  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-ncats-webd
   name: ncats_webd
-  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
-  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,11 +1,15 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
+  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-ncats-webd
   name: ncats_webd
+  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
+  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -39,7 +39,7 @@ def test_apt_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["cyhy-reports"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip_package.get_packages()
+    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,8 +12,32 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
+@pytest.mark.parametrize(
+    "pkg",
+    [
+        "python-mpltoolkits.basemap",
+        "python-numpy",
+        "python-dateutil",
+        "python-netaddr",
+        "python-pandas",
+        "python-progressbar",
+        "python-docopt",
+        "python-unicodecsv",
+        "python-pypdf2",
+        "texlive",
+        "texlive-fonts-extra",
+        "texlive-latex-extra",
+        "texlive-science",
+        "texlive-xetex",
+    ],
+)
+def test_apt_packages(host, pkg):
+    """Test that the apt packages were installed."""
+    assert host.package(pkg).is_installed
+
+
 @pytest.mark.parametrize("pkg", ["cyhy-reports"])
-def test_packages(host, pkg):
+def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
     assert pkg in host.pip_package.get_packages()
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -24,6 +24,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
         "python-docopt",
         "python-unicodecsv",
         "python-pypdf2",
+        "rsync",
         "texlive",
         "texlive-fonts-extra",
         "texlive-latex-extra",

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -45,6 +45,7 @@ def test_pip_packages(host, pkg):
 @pytest.mark.parametrize(
     "f",
     [
+        "/usr/local/share/fonts",
         "/var/local/cyhy/reports",
         "/var/cyhy/reports",
         "/var/cyhy/reports/output",

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,10 +22,10 @@
 # Install cyhy-reports
 #
 
-# These dependencies are from here:
-# https://github.com/cisagov/cal-overlay/blob/develop/net-analyzer/cyhy-reports/cyhy-reports-1.0.12.ebuild#L31-L49
+# The Python dependencies are from here:
+# https://github.com/cisagov/cyhy-reports/blob/develop/setup.py#L50-L71
 #
-# I'd prefer to install the python dependencies via pip, but then I
+# I'd prefer to install the Python dependencies via pip, but then I
 # get errors about modules being built with a different version of
 # numpy than what is on the host.  Doing it this way seems to work
 # much better.
@@ -36,7 +36,6 @@
       - python-numpy
       - python-dateutil
       - python-netaddr
-      - python-pystache
       - python-pandas
       - python-progressbar
       - python-docopt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
 
 - name: Install cyhy-reports
   ansible.builtin.pip:
+    executable: /usr/bin/pip2
     name: file:///var/local/cyhy/reports
 
 - name: Create some directories that cyhy-reports requires

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,23 +2,6 @@
 # tasks file for cyhy_reports
 
 #
-# Grab the cyhy-reports code
-#
-- name: Create the /var/local/cyhy/reports directory
-  ansible.builtin.file:
-    mode: 0755
-    path: /var/local/cyhy/reports
-    state: directory
-
-- name: Download and untar the cyhy-reports tarball
-  ansible.builtin.unarchive:
-    src: "https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop"
-    dest: /var/local/cyhy/reports
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-#
 # Install cyhy-reports
 #
 
@@ -47,12 +30,16 @@
       - texlive-science
       - texlive-xetex
 
-- name: Install cyhy-reports
+- name: Install the cyhy-reports package
   ansible.builtin.pip:
     executable: /usr/bin/pip2
-    name: file:///var/local/cyhy/reports
+    name: https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop
 
-- name: Create some directories that cyhy-reports requires
+#
+# Download the cyhy-reports code for some extra content we need
+#
+
+- name: Create the directories we need for cyhy-reports
   ansible.builtin.file:
     mode: 0755
     path: "{{ item }}"
@@ -60,6 +47,15 @@
   loop:
     - /var/cyhy/reports
     - /var/cyhy/reports/output
+    - /var/local/cyhy/reports
+
+- name: Download and untar the cyhy-reports tarball
+  ansible.builtin.unarchive:
+    src: https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop
+    dest: /var/local/cyhy/reports
+    remote_src: yes
+    extra_opts:
+      - "--strip-components=1"
 
 - name: Copy the reporting and notification scripts
   ansible.builtin.copy:
@@ -71,7 +67,7 @@
     - create_snapshots_reports_scorecard.py
     - create_send_notifications.py
 
-# rsync is required by synchronize
+# rsync is required by the synchronize module
 - name: Install rsync
   ansible.builtin.package:
     name: rsync


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the platforms supported by this Ansible role in addition to ensuring that the [cyhy-reports] package is installed with `pip2`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## ⚠ Note ##

This pull request is reliant on the merge of the following:

- cisagov/ansible-role-pip#50
- cisagov/ansible-role-python#46
- cisagov/ansible-role-cyhy-core#65
- cisagov/ansible-role-ncats-webd#58

## 💭 Motivation and context ##

We are in the process of updating the instances in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis) to use Debian Buster for instances running Python 2 code. With the above mentioned PRs for Python/pip installation we can expand the supported platforms. Additionally we update the installation process so that the [cyhy-reports] package is installed directly with pip. We still download the source tarball because it's the most convenient way to get the extras onto the host.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Revert dependencies to default branches.

[cyhy-reports]: https://github.com/cisagov/cyhy-reports
