### PR TITLE
Allow specification of the texmf buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,9 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| texmf_buffer_size | The value to use for the texmf buffer size. | `200000` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# The value to use for the texmf buffer size.
+#
+# This is the default value from the OS package.
+texmf_buffer_size: 200000

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,8 @@
 ---
-# handlers file for cyhy_reports
-
 - name: Install the cyhy-reports fonts
-  ansible.builtin.command: fc-cache --system-only
+  ansible.builtin.command:
+    cmd: /usr/bin/fc-cache --system-only
+
+- name: Ensure that any texmf config changes take effect
+  ansible.builtin.command:
+    cmd: /usr/sbin/update-texmf

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -57,3 +57,14 @@ def test_pip_packages(host, pkg):
 def test_files(host, f):
     """Test that the expected files and directories are present."""
     assert host.file(f).exists
+
+
+def test_texmf_configuration(host):
+    """Test that the texmf configuration was modified as expected."""
+    cmd = host.run("kpsewhich texmf.cnf")
+    assert cmd.rc == 0
+    texmf_config_filename = cmd.stdout.strip()
+    texmf_config_file = host.file(texmf_config_filename)
+    assert texmf_config_file.exists
+    assert texmf_config_file.is_file
+    assert texmf_config_file.contains(r"buf_size=\d*")

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -67,4 +67,11 @@ def test_texmf_configuration(host):
     texmf_config_file = host.file(texmf_config_filename)
     assert texmf_config_file.exists
     assert texmf_config_file.is_file
-    assert texmf_config_file.contains(r"buf_size=\d+")
+    # Note that File.contains() does not use Python's re library but
+    # instead runs grep behind the scenes:
+    # https://github.com/pytest-dev/pytest-testinfra/blob/main/testinfra/modules/file.py#L118-L119
+    #
+    # Therefore the regex string here must be able to be passed to
+    # grep without any quotes around it.  This is the reason I do not
+    # use an r-string and use two backslashes before the plus.
+    assert texmf_config_file.contains("buf_size=[[:digit:]]\\+")

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -67,4 +67,4 @@ def test_texmf_configuration(host):
     texmf_config_file = host.file(texmf_config_filename)
     assert texmf_config_file.exists
     assert texmf_config_file.is_file
-    assert texmf_config_file.contains(r"buf_size=\d*")
+    assert texmf_config_file.contains(r"buf_size=\d+")

--- a/tasks/install_and_configure_texlive.yml
+++ b/tasks/install_and_configure_texlive.yml
@@ -1,0 +1,17 @@
+- name: Install TeX Live
+  ansible.builtin.package:
+    name:
+      - texlive
+      - texlive-fonts-extra
+      - texlive-latex-extra
+      - texlive-science
+      - texlive-xetex
+
+- name: Create config file to increase size of texmf buffer
+  ansible.builtin.template:
+    dest: /etc/texmf/texmf.d/99buffer_size.cnf
+    group: root
+    mode: 0644
+    owner: root
+    src: buffer_size.cnf.j2
+  notify: Ensure that any texmf config changes take effect

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-# tasks file for cyhy_reports
+- name: Install and configure TeX Live
+  ansible.builtin.include_tasks: install_and_configure_texlive.yml
 
 #
 # Install cyhy-reports
@@ -24,11 +25,6 @@
       - python-docopt
       - python-unicodecsv
       - python-pypdf2
-      - texlive
-      - texlive-fonts-extra
-      - texlive-latex-extra
-      - texlive-science
-      - texlive-xetex
 
 - name: Install the cyhy-reports package
   ansible.builtin.pip:

--- a/templates/buffer_size.cnf.j2
+++ b/templates/buffer_size.cnf.j2
@@ -1,0 +1,1 @@
+buf_size={{ texmf_buffer_size }}


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to allow specification of the `texmf` buffer size.

## 💭 Motivation and context ##

TeX uses the buffer to contain input lines, but macro expansion works by writing material into the buffer and re-parsing the line.  As a consequence, certain constructs require the buffer to be very large.  As distributed by the OS package, the size is 200000, which is more than sufficient for most documents; however, we have recently seen a lengthy CyHy report that required a value greater than 500000.  This is why this change is necessary.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.