### PR TITLE
Add ability to set ownership of created files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
+| cyhy_reports_file_owner_group | The name of the group that should own any non-system files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| cyhy_reports_file_owner_username | The name of the user that should own any non-system files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 | cyhy_reports_maxmind_license_key | The MaxMind license key that provides access to a GeoIP2 database subscription. | n/a | Yes |
 | cyhy_reports_texmf_buffer_size | The value to use for the texmf buffer size. | n/a | No |
 | cyhy_reports_texmf_main_memory | The value to use for the texmf main memory size. | n/a | No |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,15 +28,15 @@
 - name: Install cyhy-reports dependencies
   ansible.builtin.package:
     name:
-      - python-mpltoolkits.basemap
-      - python-numpy
       - python-dateutil
+      - python-docopt
+      - python-mpltoolkits.basemap
       - python-netaddr
+      - python-numpy
       - python-pandas
       - python-progressbar
-      - python-docopt
-      - python-unicodecsv
       - python-pypdf2
+      - python-unicodecsv
 
 - name: Install the cyhy-reports package
   ansible.builtin.pip:
@@ -59,21 +59,21 @@
 
 - name: Download and untar the cyhy-reports tarball
   ansible.builtin.unarchive:
-    src: https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop
     dest: /var/local/cyhy/reports
-    remote_src: yes
     extra_opts:
       - "--strip-components=1"
+    remote_src: yes
+    src: https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop
 
 - name: Copy the reporting and notification scripts
   ansible.builtin.copy:
-    src: "/var/local/cyhy/reports/extras/{{ item }}"
     dest: "/var/cyhy/reports/{{ item }}"
     mode: 0755
     remote_src: yes
+    src: "/var/local/cyhy/reports/extras/{{ item }}"
   loop:
-    - create_snapshots_reports_scorecard.py
     - create_send_notifications.py
+    - create_snapshots_reports_scorecard.py
 
 # rsync is required by the synchronize module
 - name: Install rsync
@@ -82,8 +82,8 @@
 
 - name: Copy the cyhy-reports fonts
   ansible.posix.synchronize:
-    src: /var/local/cyhy/reports/cyhy_report/assets/Fonts/
     dest: /usr/local/share/fonts
+    src: /var/local/cyhy/reports/cyhy_report/assets/Fonts/
   delegate_to: "{{ inventory_hostname }}"
   register: sync_output
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,10 +67,10 @@
 
 - name: Copy the reporting and notification scripts
   ansible.builtin.copy:
-    dest: "/var/cyhy/reports/{{ item }}"
+    dest: /var/cyhy/reports/{{ item }}
     mode: 0755
     remote_src: yes
-    src: "/var/local/cyhy/reports/extras/{{ item }}"
+    src: /var/local/cyhy/reports/extras/{{ item }}
   loop:
     - create_send_notifications.py
     - create_snapshots_reports_scorecard.py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,6 +89,8 @@
 - name: Copy the cyhy-reports fonts
   ansible.posix.synchronize:
     dest: /usr/local/share/fonts
+    group: false
+    owner: false
     src: /var/local/cyhy/reports/cyhy_report/assets/Fonts/
   delegate_to: "{{ inventory_hostname }}"
   register: sync_output

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,9 @@
 
 - name: Create the directories we need for cyhy-reports
   ansible.builtin.file:
+    group: "{{ cyhy_reports_file_owner_group | default(omit) }}"
     mode: 0755
+    owner: "{{ cyhy_reports_file_owner_username | default(omit) }}"
     path: "{{ item }}"
     state: directory
   loop:
@@ -62,13 +64,17 @@
     dest: /var/local/cyhy/reports
     extra_opts:
       - "--strip-components=1"
+    group: "{{ cyhy_reports_file_owner_group | default(omit) }}"
+    owner: "{{ cyhy_reports_file_owner_username | default(omit) }}"
     remote_src: yes
     src: https://api.github.com/repos/cisagov/cyhy-reports/tarball/develop
 
 - name: Copy the reporting and notification scripts
   ansible.builtin.copy:
     dest: /var/cyhy/reports/{{ item }}
+    group: "{{ cyhy_reports_file_owner_group | default(omit) }}"
     mode: 0755
+    owner: "{{ cyhy_reports_file_owner_username | default(omit) }}"
     remote_src: yes
     src: /var/local/cyhy/reports/extras/{{ item }}
   loop:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The primary goal of this pull request is to add two optional variables that can be used to set ownership of any files or directories created by this role. However it also does a bit of alphabetical sorting (to align with our best practices).

> [!NOTE]
> Ownership of TeX Live files and synchronized fonts is intentionally not changed as they should not inherit the same file permissions as the rest of the directories and files created.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Outside of being generally useful this will allow us to set the owner of these files to the `cyhy` user when used in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis). This is a viable option now that the `cyhy` user is created before this role is called as part of the image building playbook. The rest is just cleanup while we're here.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
